### PR TITLE
chore: only trigger CI on changes to src/

### DIFF
--- a/.github/workflows/maturin-ci.yml
+++ b/.github/workflows/maturin-ci.yml
@@ -6,7 +6,12 @@
 name: ci-snob-lib
 
 on:
+  pull_request:
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
       - master


### PR DESCRIPTION
to avoid unnecessary CI runs, we only want to trigger the CI for the build of `snob_lib` when something has changed in the `src` directory